### PR TITLE
Add a check for post type

### DIFF
--- a/external-media-without-import.php
+++ b/external-media-without-import.php
@@ -55,7 +55,9 @@ add_action( 'admin_post_add_external_media_without_import', 'emwi\admin_post_add
 add_filter( 'get_attached_file', function( $file, $attachment_id ) {
 	if ( empty( $file ) ) {
 		$post = get_post( $attachment_id );
-		return $post->guid;
+		if ( get_post_type( $post ) == 'attachment' ) {
+			return $post->guid;
+		}
 	}
 	return $file;
 }, 10, 2 );


### PR DESCRIPTION
Fixing issue #10 made this plugin to return guid for every type of post.

My theme sometimes make a fallback to ID:1 which leads to errors, because this ID should return null for get_attached_file(), but it doesn't.

This is my fix.